### PR TITLE
Add distinction for defined object and undefined objects

### DIFF
--- a/source/codingstandards.rst
+++ b/source/codingstandards.rst
@@ -367,7 +367,8 @@ float     Float type (point number)
 boolean   Logical type (true or false)
 string    String type (any value in ``""`` or ``' '``)
 array     Array type
-object    Object type
+objectClass    Type defined object
+object    Undefined type object (can be different classes, ...)
 ressource Resource type (as returned from ``mysql_connect`` function)
 ========= ===========
 


### PR DESCRIPTION
Fix #28 