### PR TITLE
Typo between "summary" and file name

### DIFF
--- a/source/plugins/objects.rst
+++ b/source/plugins/objects.rst
@@ -78,7 +78,7 @@ First, create the ``inc/myobject.class.php`` file that looks like:
       }
    }
 
-The ``inc/myobject.php`` file will be in charge to list objects. It should look like:
+The ``front/myobject.php`` file will be in charge to list objects. It should look like:
 
 .. code-block:: php
 


### PR DESCRIPTION
In the "summary" you say:
` * a front file to handle display (``front/myobject.php``),`
And in the example
` The ``inc/myobject.php`` file will be in charge to list objects. It should look like: `
I think it is in the code block where the typo is.