### PR TITLE
Add Kanban Hooks

### DIFF
--- a/source/plugins/hooks.rst
+++ b/source/plugins/hooks.rst
@@ -188,6 +188,34 @@ Hooks that cannot be classified in above categories :)
 ``change_profile``
    When profile is changed
 
+``pre_kanban_content``
+   Set or modify the content that shows before the main content in a Kanban card.
+
+   This hook will receive a specific array that looks like:
+
+   .. code-block:: php
+
+      <?php
+      $hook_params = [
+         'itemtype'  => string, //item type that is showing the Kanban
+         'items_id'  => int, //ID of itemtype showing the Kanban
+         'content'   => string //current content shown before main content
+      ];
+
+``post_kanban_content``
+   Set or modify the content that shows after the main content in a Kanban card.
+
+   This hook will receive a specific array that looks like:
+
+   .. code-block:: php
+
+      <?php
+      $hook_params = [
+         'itemtype'  => string, //item type that is showing the Kanban
+         'items_id'  => int, //ID of itemtype showing the Kanban
+         'content'   => string //current content shown after main content
+      ];
+
 Items business related
 ++++++++++++++++++++++
 


### PR DESCRIPTION
Document the new hooks added with the Kanban feature in 9.5.0. The feature PR is still open so documentation is subject to change.

I will mark this PR as ready for review after feature is merged.