### PR TITLE
Allow class string type in PHPDoc

### DIFF
--- a/source/codingstandards.rst
+++ b/source/codingstandards.rst
@@ -174,18 +174,19 @@ Variables types
 
 Variables types for use in DocBlocks for Doxygen:
 
-========= ===========
- Type     Description
-========= ===========
-mixed     A variable with undefined (or multiple) type
-integer   Integer type variable (whole number)
-float     Float type (point number)
-boolean   Logical type (true or false)
-string    String type (any value in ``""`` or ``' '``)
-array     Array type
-object    Object type
-ressource Resource type (as returned from ``mysql_connect`` function)
-========= ===========
+============ ===========
+ Type        Description
+============ ===========
+mixed        A variable with undefined (or multiple) type
+integer      Integer type variable (whole number)
+float        Float type (point number)
+boolean      Logical type (true or false)
+string       String type (any value in ``""`` or ``' '``)
+array        Array type
+object       Object type
+resource     Resource type (as returned from ``mysql_connect`` function)
+class-string A string that represents a class name (Used by PHPStan and supported by some IDEs)
+============ ===========
 
 Inserting comment in source code for doxygen.
 Result : full doc for variables, functions, classes...

--- a/source/codingstandards.rst
+++ b/source/codingstandards.rst
@@ -174,19 +174,19 @@ Variables types
 
 Variables types for use in DocBlocks for Doxygen:
 
-============ ===========
- Type        Description
-============ ===========
-mixed        A variable with undefined (or multiple) type
-integer      Integer type variable (whole number)
-float        Float type (point number)
-boolean      Logical type (true or false)
-string       String type (any value in ``""`` or ``' '``)
-array        Array type
-object       Object type
-resource     Resource type (as returned from ``mysql_connect`` function)
-class-string A string that represents a class name (Used by PHPStan and supported by some IDEs)
-============ ===========
+=============== ===========
+ Type           Description
+=============== ===========
+mixed           A variable with undefined (or multiple) type
+integer         Integer type variable (whole number)
+float           Float type (point number)
+boolean         Logical type (true or false)
+string          String type (any value in ``""`` or ``' '``)
+array           Array type
+object          Object type
+resource        Resource type (as returned from ``mysql_connect`` function)
+class-string<T> A string that represents a class name where T is the class (or a common parent class)
+=============== ===========
 
 Inserting comment in source code for doxygen.
 Result : full doc for variables, functions, classes...


### PR DESCRIPTION
Currently, we have a lot of places where we return a string or accept a string in a function that is a class name. This string then gets used to access static members which is valid for PHP but IDEs don't have any information about the type and will throw warnings about methods or properties not being found (At least for PHPStorm).

In order to get autocomplete and other information from the IDE, we had two solutions:
1. Use a union in the PHPDoc such as `string|CommonDBTM`. This is wrong though since we don't return or accept an instance of CommonDBTM and that could lead to unexpected behavior especially if no language-level typehints are used.
2. Use a `var` PHPDoc statement to typehint the argument or returned value such as:
```php
/** @var CommonDBTM $some_var */
$some_var = $this->getSomeClassString();
```
This is the cleaner solution but isn't widely used in the code yet.

This PR proposes allowing the use of `class-string` in the PHPDocs to accurately document that the value is a string but also represents a class name. This is used by PHPStan and Psalm but some IDEs have support for these tools built-in such as PHPStorm. I cannot say how many other IDEs support this syntax though.

If this isn't sufficiently supported by IDEs, ideally this would be used along with a `string` language-level typehint but it could also be used as a union in the PHPDoc like:
```php
/**
* @return class-string<CommonDBTM>|string
*/
```