### PR TITLE
Allow all PHPStan type definitions

### DIFF
--- a/source/codingstandards.rst
+++ b/source/codingstandards.rst
@@ -185,8 +185,9 @@ string          String type (any value in ``""`` or ``' '``)
 array           Array type
 object          Object type
 resource        Resource type (as returned from ``mysql_connect`` function)
-class-string<T> A string that represents a class name where T is the class (or a common parent class)
 =============== ===========
+
+In addition to the above, you may use any valid types from `PHPStan <https://phpstan.org/writing-php-code/phpdoc-types>`_.
 
 Inserting comment in source code for doxygen.
 Result : full doc for variables, functions, classes...


### PR DESCRIPTION
Rather than adding them individually like `class-string`, simply state that all PHPStan types can be used especially if we are going to be utilizing this tool in the future.
See: https://github.com/glpi-project/glpi/pull/9827