### PR TITLE
Fix text datatypes

### DIFF
--- a/source/devapi/search.rst
+++ b/source/devapi/search.rst
@@ -401,11 +401,11 @@ Available datatypes for search are:
 
 ``text``
 
-   Simple text
+   Use text area input for modification (optionally rich-text)
 
 ``string``
 
-   Use a rich text editor for modification
+   Simple, single-line text
 
 ``ip``
 


### PR DESCRIPTION
String is used in GLPI for simple one-line inputs like `Serial Number` while `text` is used for fields like `Comments` and `Content`. There may be some cases where the datatypes are mixed up in the core, but this seems like the intended purpose for the datatypes.