### PR TITLE
Update sources location references

### DIFF
--- a/source/devapi/mainobjects.rst
+++ b/source/devapi/mainobjects.rst
@@ -1,7 +1,8 @@
 Main framework objects
 ----------------------
 
-GLPI contains numerous classes; but there are a few common objects you'd have to know about. All GLPI classes are in the ``inc`` directory.
+GLPI contains numerous classes; but there are a few common objects you'd have to know about. All GLPI classes are in the ``src`` directory.
+Prior to GLPI 10.0, the classes were in the ``inc`` directory. Now, only non-class PHP files remain there.
 
 .. note::
 
@@ -10,7 +11,7 @@ GLPI contains numerous classes; but there are a few common objects you'd have to
 CommonGLPI
 ^^^^^^^^^^
 
-This is **the** main GLPI object, most of GLPI or Plugins class inherit from this one, directly or not. The class is in the ``inc/commonglpi.class.php`` file.
+This is **the** main GLPI object, most of GLPI or Plugins class inherit from this one, directly or not. The class is in the ``src/CommonGLPI.php`` file.
 
 This object will help you to:
 
@@ -25,7 +26,7 @@ This object will help you to:
 CommonDBTM
 ^^^^^^^^^^
 
-This is an object to manage any database stuff; it of course inherits from `CommonGLPI`_. The class is in the ``inc/commondbtm.class.php`` file.
+This is an object to manage any database stuff; it of course inherits from `CommonGLPI`_. The class is in the ``src/CommonDBTM.php`` file.
 
 It aims to manage database persistence and tables for all objects; and will help you to:
 
@@ -39,7 +40,7 @@ The CommonDBTM object provides several of the :doc:`available hooks <../plugins/
 CommonDropdown
 ^^^^^^^^^^^^^^
 
-This class aims to manage dropdown (lists) database stuff. It inherits from `CommonDBTM`_. The class is in the ``inc/commondropdown.class.php`` file.
+This class aims to manage dropdown (lists) database stuff. It inherits from `CommonDBTM`_. The class is in the ``src/CommonDropdown.php`` file.
 
 It will help you to:
 
@@ -50,19 +51,19 @@ It will help you to:
 CommonTreeDropdown
 ^^^^^^^^^^^^^^^^^^
 
-This class aims to manage tree lists database stuff. It inherits from `CommonDropdown`_. The class is in the ``inc/commontreedropdown.class.php`` file.
+This class aims to manage tree lists database stuff. It inherits from `CommonDropdown`_. The class is in the ``src/CommonTreeDropdown.php`` file.
 
 It will mainly help you to manage the tree apsect of a dropdown (parents, children, and so on).
 
 CommonImplicitTreeDropdown
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This class manages tree lists that cannot be managed by the user. It inherits from `CommonTreeDropdown`_. The class is in the ``inc/commonimplicittreedropdown.class.php`` file.
+This class manages tree lists that cannot be managed by the user. It inherits from `CommonTreeDropdown`_. The class is in the ``src/CommonImplicitTreeDropdown.php`` file.
 
 CommonDBVisible
 ^^^^^^^^^^^^^^^
 
-This class helps with visibility management. It inherits from `CommonDBTM`_. The class is in the ``inc/commondbvisible.class.php`` file.
+This class helps with visibility management. It inherits from `CommonDBTM`_. The class is in the ``src/CommonDBVisible.php`` file.
 
 It provides methods to:
 
@@ -73,21 +74,21 @@ It provides methods to:
 CommonDBConnexity
 ^^^^^^^^^^^^^^^^^
 
-This class factorizes database relation and inheritance stuff. It inherits from `CommonDBTM`_. The class is in the ``inc/commondbconnexity.class.php`` file.
+This class factorizes database relation and inheritance stuff. It inherits from `CommonDBTM`_. The class is in the ``src/CommonDBConnexity.php`` file.
 
 It is not designed to be used directly, see `CommonDBChild`_ and `CommonDBRelation`_.
 
 CommonDBChild
 ^^^^^^^^^^^^^
 
-This class manages simple relations. It inherits from `CommonDBConnexity`_. The class is in the ``inc/commondbchild.class.php`` file.
+This class manages simple relations. It inherits from `CommonDBConnexity`_. The class is in the ``src/CommonDBChild.php`` file.
 
 This object will help you to define and manage parent/child relations.
 
 CommonDBRelation
 ^^^^^^^^^^^^^^^^
 
-This class manages relations. It inherits from `CommonDBConnexity`_. The class is in the ``inc/commondbrelation.class.php`` file.
+This class manages relations. It inherits from `CommonDBConnexity`_. The class is in the ``src/CommonDBRelation.php`` file.
 
 Unlike `CommonDBChild`_; it is designed to declare more :ref:`complex relations; as defined in the database model <complex-relations>`. This is therefore more complex thant just using a simple relation; but it also offers many more possibilities.
 
@@ -108,7 +109,7 @@ The object will also help you to:
 CommonDevice
 ^^^^^^^^^^^^
 
-This class factorizes common requirements on devices. It inherits from `CommonDropdown`_. The class is in the ``inc/commondevice.class.php`` file.
+This class factorizes common requirements on devices. It inherits from `CommonDropdown`_. The class is in the ``src/CommonDevice.php`` file.
 
 It will help you to:
 
@@ -124,7 +125,7 @@ All common ITIL objects will help you with `ITIL <https://en.wikipedia.org/wiki/
 CommonITILObject
 ++++++++++++++++
 
-Handle ITIL objects. It inherits from `CommonDBTM`_. The class is in the ``inc/commonitilobject.class.php`` file.
+Handle ITIL objects. It inherits from `CommonDBTM`_. The class is in the ``src/CommonITILObject.php`` file.
 
 It will help you to:
 
@@ -137,7 +138,7 @@ It will help you to:
 CommonITILActor
 +++++++++++++++
 
-Handle ITIL actors. It inherits from `CommonDBRelation`_. The class is in the ``inc/commonitilactor.class.php`` file.
+Handle ITIL actors. It inherits from `CommonDBRelation`_. The class is in the ``src/CommonITILActor.php`` file.
 
 It will help you to:
 
@@ -149,7 +150,7 @@ It will help you to:
 CommonITILCost
 ++++++++++++++
 
-Handle ITIL costs. It inherits from `CommonDBChild`_. The class is in the ``inc/commonitilcost.class.php`` file.
+Handle ITIL costs. It inherits from `CommonDBChild`_. The class is in the ``src/CommonITILCost.php`` file.
 
 It will help you to:
 
@@ -160,7 +161,7 @@ It will help you to:
 CommonITILTask
 ++++++++++++++
 
-Handle ITIL tasks. It inherits from `CommonDBTM`_. The class is in the ``inc/commonitiltask.class.php`` file.
+Handle ITIL tasks. It inherits from `CommonDBTM`_. The class is in the ``src/CommonITILTask.php`` file.
 
 It will help you to:
 
@@ -172,7 +173,7 @@ It will help you to:
 CommonITILValidation
 ++++++++++++++++++++
 
-Handle ITIL validation process. It inherits from `CommonDBChild`_. The class is in the ``inc/commonitilvalidation.class.php`` file.
+Handle ITIL validation process. It inherits from `CommonDBChild`_. The class is in the ``src/CommonITILValidation.php`` file.
 
 It will help you to:
 

--- a/source/devapi/mainobjects.rst
+++ b/source/devapi/mainobjects.rst
@@ -11,7 +11,7 @@ Prior to GLPI 10.0, the classes were in the ``inc`` directory. Now, only non-cla
 CommonGLPI
 ^^^^^^^^^^
 
-This is **the** main GLPI object, most of GLPI or Plugins class inherit from this one, directly or not. The class is in the ``src/CommonGLPI.php`` file.
+This is **the** main GLPI object, most of GLPI or Plugins class inherit from this one, directly or not.
 
 This object will help you to:
 
@@ -26,7 +26,7 @@ This object will help you to:
 CommonDBTM
 ^^^^^^^^^^
 
-This is an object to manage any database stuff; it of course inherits from `CommonGLPI`_. The class is in the ``src/CommonDBTM.php`` file.
+This is an object to manage any database stuff; it of course inherits from `CommonGLPI`_.
 
 It aims to manage database persistence and tables for all objects; and will help you to:
 
@@ -40,7 +40,7 @@ The CommonDBTM object provides several of the :doc:`available hooks <../plugins/
 CommonDropdown
 ^^^^^^^^^^^^^^
 
-This class aims to manage dropdown (lists) database stuff. It inherits from `CommonDBTM`_. The class is in the ``src/CommonDropdown.php`` file.
+This class aims to manage dropdown (lists) database stuff. It inherits from `CommonDBTM`_.
 
 It will help you to:
 
@@ -51,19 +51,19 @@ It will help you to:
 CommonTreeDropdown
 ^^^^^^^^^^^^^^^^^^
 
-This class aims to manage tree lists database stuff. It inherits from `CommonDropdown`_. The class is in the ``src/CommonTreeDropdown.php`` file.
+This class aims to manage tree lists database stuff. It inherits from `CommonDropdown`_.
 
 It will mainly help you to manage the tree apsect of a dropdown (parents, children, and so on).
 
 CommonImplicitTreeDropdown
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This class manages tree lists that cannot be managed by the user. It inherits from `CommonTreeDropdown`_. The class is in the ``src/CommonImplicitTreeDropdown.php`` file.
+This class manages tree lists that cannot be managed by the user. It inherits from `CommonTreeDropdown`_.
 
 CommonDBVisible
 ^^^^^^^^^^^^^^^
 
-This class helps with visibility management. It inherits from `CommonDBTM`_. The class is in the ``src/CommonDBVisible.php`` file.
+This class helps with visibility management. It inherits from `CommonDBTM`_.
 
 It provides methods to:
 
@@ -74,21 +74,21 @@ It provides methods to:
 CommonDBConnexity
 ^^^^^^^^^^^^^^^^^
 
-This class factorizes database relation and inheritance stuff. It inherits from `CommonDBTM`_. The class is in the ``src/CommonDBConnexity.php`` file.
+This class factorizes database relation and inheritance stuff. It inherits from `CommonDBTM`_.
 
 It is not designed to be used directly, see `CommonDBChild`_ and `CommonDBRelation`_.
 
 CommonDBChild
 ^^^^^^^^^^^^^
 
-This class manages simple relations. It inherits from `CommonDBConnexity`_. The class is in the ``src/CommonDBChild.php`` file.
+This class manages simple relations. It inherits from `CommonDBConnexity`_.
 
 This object will help you to define and manage parent/child relations.
 
 CommonDBRelation
 ^^^^^^^^^^^^^^^^
 
-This class manages relations. It inherits from `CommonDBConnexity`_. The class is in the ``src/CommonDBRelation.php`` file.
+This class manages relations. It inherits from `CommonDBConnexity`_.
 
 Unlike `CommonDBChild`_; it is designed to declare more :ref:`complex relations; as defined in the database model <complex-relations>`. This is therefore more complex thant just using a simple relation; but it also offers many more possibilities.
 
@@ -109,7 +109,7 @@ The object will also help you to:
 CommonDevice
 ^^^^^^^^^^^^
 
-This class factorizes common requirements on devices. It inherits from `CommonDropdown`_. The class is in the ``src/CommonDevice.php`` file.
+This class factorizes common requirements on devices. It inherits from `CommonDropdown`_.
 
 It will help you to:
 
@@ -125,7 +125,7 @@ All common ITIL objects will help you with `ITIL <https://en.wikipedia.org/wiki/
 CommonITILObject
 ++++++++++++++++
 
-Handle ITIL objects. It inherits from `CommonDBTM`_. The class is in the ``src/CommonITILObject.php`` file.
+Handle ITIL objects. It inherits from `CommonDBTM`_.
 
 It will help you to:
 
@@ -138,7 +138,7 @@ It will help you to:
 CommonITILActor
 +++++++++++++++
 
-Handle ITIL actors. It inherits from `CommonDBRelation`_. The class is in the ``src/CommonITILActor.php`` file.
+Handle ITIL actors. It inherits from `CommonDBRelation`_.
 
 It will help you to:
 
@@ -150,7 +150,7 @@ It will help you to:
 CommonITILCost
 ++++++++++++++
 
-Handle ITIL costs. It inherits from `CommonDBChild`_. The class is in the ``src/CommonITILCost.php`` file.
+Handle ITIL costs. It inherits from `CommonDBChild`_.
 
 It will help you to:
 
@@ -161,7 +161,7 @@ It will help you to:
 CommonITILTask
 ++++++++++++++
 
-Handle ITIL tasks. It inherits from `CommonDBTM`_. The class is in the ``src/CommonITILTask.php`` file.
+Handle ITIL tasks. It inherits from `CommonDBTM`_.
 
 It will help you to:
 
@@ -173,7 +173,7 @@ It will help you to:
 CommonITILValidation
 ++++++++++++++++++++
 
-Handle ITIL validation process. It inherits from `CommonDBChild`_. The class is in the ``src/CommonITILValidation.php`` file.
+Handle ITIL validation process. It inherits from `CommonDBChild`_.
 
 It will help you to:
 

--- a/source/devapi/rules.rst
+++ b/source/devapi/rules.rst
@@ -87,7 +87,7 @@ Add a new Rule class
 Here is the minimal setup to have a working set.
 You need to add the following classes for describing you new ``sub_type``.
 
-* ``inc/rulemytype.class.php``
+* ``src/RuleMytype.php``
 
 .. code-block:: php
 
@@ -157,7 +157,7 @@ You need to add the following classes for describing you new ``sub_type``.
         }
     }
 
-* ``inc/rulemytypecollection.class.php``
+* ``src/RuleMytypeCollection.class.php``
 
 .. code-block:: php
 

--- a/source/devapi/rules.rst
+++ b/source/devapi/rules.rst
@@ -157,7 +157,7 @@ You need to add the following classes for describing you new ``sub_type``.
         }
     }
 
-* ``src/RuleMytypeCollection.class.php``
+* ``src/RuleMytypeCollection.php``
 
 .. code-block:: php
 

--- a/source/plugins/notifications.rst
+++ b/source/plugins/notifications.rst
@@ -74,7 +74,7 @@ You will probably need some configuration settings to get your notifications mod
    $conf = Config::getConfigurationValues('plugin:sms');
    //$conf will be ['server' => '', 'port' => '']
 
-That said, we need to create a class to handle the settings, and a front file to display them. The class must be named ``GlpiPlugin\Sms\NotificationSmsSetting`` and must be in the ``src/NotificationSmsSetting.class.php``. It have to extends the ``NotificationSetting`` core class :
+That said, we need to create a class to handle the settings, and a front file to display them. The class must be named ``GlpiPlugin\Sms\NotificationSmsSetting`` and must be in the ``src/NotificationSmsSetting.php`` file. It have to extends the ``NotificationSetting`` core class :
 
 .. code-block:: php
 
@@ -168,7 +168,7 @@ The front form file, located at ``front/notificationsmssetting.form.php`` will b
 Event
 ^^^^^
 
-Once the new mode has been enabled; it will try to raise core events. You will need to create an event class named ``GlpiPlugin\Sms\NotificationEventSms`` that implements ``NotificationEventInterface`` and extends ``NotificationEventAbstract`` in the ``inc/notificationeventsms.php``.
+Once the new mode has been enabled; it will try to raise core events. You will need to create an event class named ``GlpiPlugin\Sms\NotificationEventSms`` that implements ``NotificationEventInterface`` and extends ``NotificationEventAbstract`` in the ``src/NotificationEventSms.php`` file.
 
 Methods to implement are:
 

--- a/source/plugins/notifications.rst
+++ b/source/plugins/notifications.rst
@@ -74,11 +74,12 @@ You will probably need some configuration settings to get your notifications mod
    $conf = Config::getConfigurationValues('plugin:sms');
    //$conf will be ['server' => '', 'port' => '']
 
-That said, we need to create a class to handle the settings, and a front file to display them. The class must be named ``PluginSmsNotificationSmsSetting`` and must be in the ``inc/notificationsmssetting.class.php``. It have to extends the ``NotificationSetting`` core class :
+That said, we need to create a class to handle the settings, and a front file to display them. The class must be named ``GlpiPlugin\Sms\NotificationSmsSetting`` and must be in the ``src/NotificationSmsSetting.class.php``. It have to extends the ``NotificationSetting`` core class :
 
 .. code-block:: php
 
    <?php
+   namespace GlpiPlugin\Sms;
    if (!defined('GLPI_ROOT')) {
       die("Sorry. You can't access this file directly");
    }
@@ -86,7 +87,7 @@ That said, we need to create a class to handle the settings, and a front file to
    /**
    *  This class manages the sms notifications settings
    */
-   class PluginSmsNotificationSmsSetting extends NotificationSetting {
+   class NotificationSmsSetting extends NotificationSetting {
 
 
       static function getTypeName($nb=0) {
@@ -143,13 +144,14 @@ The front form file, located at ``front/notificationsmssetting.form.php`` will b
 .. code-block:: php
 
    <?php
+   use Glpi\Plugin\Sms\NotificationSmsSetting;
    include ('../../../inc/includes.php');
 
    Session::checkRight("config", UPDATE);
-   $notificationsms = new PluginSmsNotificationSmsSetting();
+   $notificationsms = new NotificationSmsSetting();
 
    if (!empty($_POST["test_sms_send"])) {
-      PluginSmsNotificationSms::testNotification();
+      NotificationSmsSetting::testNotification();
       Html::back();
    } else if (!empty($_POST["update"])) {
       $config = new Config();
@@ -166,7 +168,7 @@ The front form file, located at ``front/notificationsmssetting.form.php`` will b
 Event
 ^^^^^
 
-Once the new mode has been enabled; it will try to raise core events. You will need to create an event class named ``PluginSmsNotificationEventSms`` that implements ``NotificationEventInterface`` and extends ``NotificationEventAbstract`` in the ``inc/notificationeventsms.php``.
+Once the new mode has been enabled; it will try to raise core events. You will need to create an event class named ``GlpiPlugin\Sms\NotificationEventSms`` that implements ``NotificationEventInterface`` and extends ``NotificationEventAbstract`` in the ``inc/notificationeventsms.php``.
 
 Methods to implement are:
 
@@ -188,7 +190,8 @@ En example class for SMS Events would look like the following:
 .. code-block:: php
 
    <?php
-   class PluginSmsNotificationEventSms implements NotificationEventInterface {
+   namespace GlpiPlugin\Sms;
+   class NotificationEventSms implements NotificationEventInterface {
 
       static public function getTargetFieldName() {
          return 'phone';
@@ -263,7 +266,7 @@ En example class for SMS Events would look like the following:
 Notification
 ^^^^^^^^^^^^
 
-Finally, create a ``NotificationSms`` class that implements the ``NotificationInterface`` in the ``inc/notificationsms.php`` file.
+Finally, create a ``GlpiPlugin\Sms\NotificationSms`` class that implements the ``NotificationInterface`` in the ``src/NotificationSms.php`` file.
 
 Methods to implement are:
 
@@ -276,7 +279,8 @@ Again, the SMS example:
 .. code-block:: php
 
    <?php
-   class PluginSmsNotificationSms implements NotificationInterface {
+   namespace GlpiPlugin\Sms;
+   class NotificationSms implements NotificationInterface {
 
       static function check($value, $options = []) {
          //Does nothing, but we could check if $value is actually what we expect as a phone number to send SMS.

--- a/source/plugins/objects.rst
+++ b/source/plugins/objects.rst
@@ -32,7 +32,7 @@ You will need:
 * a front file to handle display (``front/myobject.php``),
 * a front file to handle form display (``front/myobject.form.php``).
 
-First, create the ``src/MyObject.class.php`` file that looks like:
+First, create the ``src/MyObject.php`` file that looks like:
 
 .. code-block:: php
 

--- a/source/plugins/objects.rst
+++ b/source/plugins/objects.rst
@@ -9,13 +9,15 @@ Define an object
 Objects definitions will be stored into the ``inc/`` or ``src/`` directory of your plugin.
 It is recommended to place all class files in the ``src`` if possible.
 As of GLPI 10.0, namespaces should be supported in almost all cases. Therefore, it is recommended to use namespaces for your plugin classes.
-For example, if your plugin is ``MyExamplePlugin``, you should use the ``GlpiPlugin\MyExamplePlugin`` namespace.
+For example, if your plugin is ``MyExamplePlugin``, you should use the ``GlpiPlugin\Myexampleplugin`` namespace.
+Note that the plugin name part of the namespace must be lowercase with the exception of the first letter.
+Child namespaces of ``GlpiPlugin\Myexampleplugin`` do not need to follow this rule.
 
 Depending on where your class files are stored, the naming convention will be different:
 - inc: File name will be the name of your class, lowercase; the class name will be the concatenation of your plugin name and your class name.
   For example, if you want to create the ``MyObject`` in ``MyExamplePlugin``; you will create the ``inc/myobject.class.php`` file; and the class name will be ``MyExamplePluginMyObject``.
 - src: File name will match the name of your class exactly. The class name should not be prefixed by your plugin name when using namespaces. Namespaces are supported and can be reflected as subfolders.
-  For example, if your class is ``GlpiPlugin\MyExamplePlugin\NS\MyObject``, the file will be ``src/NS/MyObject.php``.
+  For example, if your class is ``GlpiPlugin\Myexampleplugin\NS\MyObject``, the file will be ``src/NS/MyObject.php``.
 
 Your object will extends one of the :doc:`common core types <../devapi/mainobjects>` (``CommonDBTM`` in our example).
 
@@ -37,7 +39,7 @@ First, create the ``src/MyObject.php`` file that looks like:
 .. code-block:: php
 
    <?php
-   namespace GlpiPlugin\MyExamplePlugin;
+   namespace GlpiPlugin\Myexampleplugin;
 
    class MyObject extends CommonDBTM {
       public function showForm($ID, array $options = []) {
@@ -92,7 +94,7 @@ The ``front/myobject.php`` file will be in charge to list objects. It should loo
 .. code-block:: php
 
    <?php
-   use GlpiPlugin\MyExamplePlugin\MyObject;
+   use GlpiPlugin\Myexampleplugin\MyObject;
    include ("../../../inc/includes.php");
 
    // Check if plugin is activated...

--- a/source/plugins/objects.rst
+++ b/source/plugins/objects.rst
@@ -6,9 +6,16 @@ In most of the cases; your plugin will have to manage several objects
 Define an object
 ++++++++++++++++
 
-Objects definitions will be stored into the ``inc/`` directory of your plugin. File name will be the name of your class in lowercase; the class name will be the concatenation of your plugin name and your class name.
+Objects definitions will be stored into the ``inc/`` or ``src/`` directory of your plugin.
+It is recommended to place all class files in the ``src`` if possible.
+As of GLPI 10.0, namespaces should be supported in almost all cases. Therefore, it is recommended to use namespaces for your plugin classes.
+For example, if your plugin is ``MyExamplePlugin``, you should use the ``GlpiPlugin\MyExamplePlugin`` namespace.
 
-For example, if you want to create the ``MyObject`` in ``MyExamplePlugin``; you will create the ``inc/myobject.class.php`` file; and the class name will be ``MyExamplePluginMyObject``.
+Depending on where your class files are stored, the naming convention will be different:
+- inc: File name will be the name of your class, lowercase; the class name will be the concatenation of your plugin name and your class name.
+  For example, if you want to create the ``MyObject`` in ``MyExamplePlugin``; you will create the ``inc/myobject.class.php`` file; and the class name will be ``MyExamplePluginMyObject``.
+- src: File name will match the name of your class exactly. The class name should not be prefixed by your plugin name when using namespaces. Namespaces are supported and can be reflected as subfolders.
+  For example, if your class is ``GlpiPlugin\MyExamplePlugin\NS\MyObject``, the file will be ``src/NS/MyObject.php``.
 
 Your object will extends one of the :doc:`common core types <../devapi/mainobjects>` (``CommonDBTM`` in our example).
 
@@ -21,17 +28,19 @@ The goal is to build CRUD (Create, Read, Update, Delete) and list views for your
 
 You will need:
 
-* a class for your object (``inc/myobject.class.php``),
+* a class for your object (``src/MyObject.php``),
 * a front file to handle display (``front/myobject.php``),
 * a front file to handle form display (``front/myobject.form.php``).
 
-First, create the ``inc/myobject.class.php`` file that looks like:
+First, create the ``src/MyObject.class.php`` file that looks like:
 
 .. code-block:: php
 
    <?php
-   class PluginMyExampleMyObject extends CommonDBTM {
-      public function showForm($ID, $options = []) {
+   namespace GlpiPlugin\MyExamplePlugin;
+
+   class MyObject extends CommonDBTM {
+      public function showForm($ID, array $options = []) {
          global $CFG_GLPI;
 
          $this->initForm($ID, $options);
@@ -83,6 +92,7 @@ The ``front/myobject.php`` file will be in charge to list objects. It should loo
 .. code-block:: php
 
    <?php
+   use GlpiPlugin\MyExamplePlugin\MyObject;
    include ("../../../inc/includes.php");
 
    // Check if plugin is activated...
@@ -92,7 +102,7 @@ The ``front/myobject.php`` file will be in charge to list objects. It should loo
    }
 
    //check for ACLs
-   if (PluginMyExampleMyObject::canView()) {
+   if (MyObject::canView()) {
       //View is granted: display the list.
 
       //Add page header
@@ -100,11 +110,11 @@ The ``front/myobject.php`` file will be in charge to list objects. It should loo
          __('My example plugin', 'myexampleplugin'),
          $_SERVER['PHP_SELF'],
          'assets',
-         'pluginmyexamplemyobject',
+         MyObject::class,
          'myobject'
       );
 
-      Search::show('PluginMyExampleMyObject');
+      Search::show(MyObject::class);
 
       Html::footer();
    } else {
@@ -117,6 +127,7 @@ And finally, the ``front/myobject.form.php`` will be in charge of CRUD operation
 .. code-block:: php
 
    <?php
+   use GlpiPlugin\MyExamplePlugin\MyObject;
    include ("../../../inc/includes.php");
 
    // Check if plugin is activated...
@@ -125,7 +136,7 @@ And finally, the ``front/myobject.form.php`` will be in charge of CRUD operation
       Html::displayNotFoundError();
    }
 
-   $object = new PluginMyExampleMyObject();
+   $object = new MyObject();
 
    if (isset($_POST['add'])) {
       //Check CREATE ACL

--- a/source/plugins/tips.rst
+++ b/source/plugins/tips.rst
@@ -17,7 +17,7 @@ First, in the ``plugin_init_{plugin_name}`` function, add the following:
    <?php
    //[...]
    Plugin::registerClass(
-      'PluginMyExampleMyClass', [
+      GlpiPlugin\MyExample\MyClass::class, [
          'addtabon' => [
             'Computer',
             'Phone'
@@ -28,7 +28,7 @@ First, in the ``plugin_init_{plugin_name}`` function, add the following:
 
 Here, we request to add a tab on `Computer` and `Phone` objects.
 
-Then, in your ``inc/myclass.php`` (in which ``PluginMyExampleMyClass`` is defined):
+Then, in your ``src/MyClass.php`` (in which ``MyClass`` is defined):
 
 .. code-block:: php
 
@@ -82,7 +82,7 @@ In order to add a new tab on your plugin object, you will have to:
 * use ``displayTabContentForItem()`` to display tab contents.
 
 
-Then, in your ``inc/myclass.php``:
+Then, in your ``src/MyClass.php``:
 
 .. code-block:: php
 
@@ -154,11 +154,11 @@ On the same model you create one tab, you may add several tabs.
 Add an object in dropdowns
 ++++++++++++++++++++++++++
 
-Just add the following to your object class (``inc/myobject.class.php``):
+Just add the following to your object class (``src/MyObject.class.php``):
 
 .. code-block:: php
 
    <?php
    function plugin_myexampleplugin_getDropdown() {
-      return ['PluginMyExampleMyObject' => PluginMyExampleMyObject::getTypeName(2)];
+      return [MyObject::class => MyObject::getTypeName(2)];
    }

--- a/source/plugins/tips.rst
+++ b/source/plugins/tips.rst
@@ -17,7 +17,7 @@ First, in the ``plugin_init_{plugin_name}`` function, add the following:
    <?php
    //[...]
    Plugin::registerClass(
-      GlpiPlugin\MyExample\MyClass::class, [
+      GlpiPlugin\Myexample\MyClass::class, [
          'addtabon' => [
             'Computer',
             'Phone'

--- a/source/plugins/tips.rst
+++ b/source/plugins/tips.rst
@@ -154,7 +154,7 @@ On the same model you create one tab, you may add several tabs.
 Add an object in dropdowns
 ++++++++++++++++++++++++++
 
-Just add the following to your object class (``src/MyObject.class.php``):
+Just add the following to your object class (``src/MyObject.php``):
 
 .. code-block:: php
 


### PR DESCRIPTION
Classes are now in `src` and it should be the preferred folder for classes in plugins as well. Additionally, namespaces should be supported for most things now and should be recommended for plugins instead of using classes with the `PluginMyplugin` prefix on the classes in the global namespace.