### PR TITLE
Update db iterator docs

### DIFF
--- a/source/devapi/database/dbiterator.rst
+++ b/source/devapi/database/dbiterator.rst
@@ -324,11 +324,11 @@ A field name and its wanted value:
    $DB->request(['FROM' => 'glpi_computers', 'WHERE' => ['is_deleted' => 0]]);
    // => SELECT * FROM `glpi_computers` WHERE `is_deleted` = 0
 
-   $DB->request('glpi_computers', 'WHERE' => ['is_deleted' => 0,
+   $DB->request(['FROM' => 'glpi_computers', 'WHERE' => ['is_deleted' => 0,
                                    'name'       => 'foo']);
    // => SELECT * FROM `glpi_computers` WHERE `is_deleted` = 0 AND `name` = 'foo'
 
-   $DB->request('glpi_computers', 'WHERE' => ['users_id' => [1,5,7]]);
+   $DB->request(['FROM' => 'glpi_computers', 'WHERE' => ['users_id' => [1,5,7]]]);
    // => SELECT * FROM `glpi_computers` WHERE `users_id` IN (1, 5, 7)
 
 When using an array as a value, the operator is automatically set to ``IN``.
@@ -344,11 +344,11 @@ Using the ``OR``, ``AND``, or ``NOT`` option with an array of criteria:
 .. code-block:: php
 
    <?php
-   $DB->request('glpi_computers', 'WHERE' => ['OR' => ['is_deleted' => 0,
-                                            'name'       => 'foo']]);
+   $DB->request(['FROM' => 'glpi_computers', 'WHERE' => ['OR' => ['is_deleted' => 0,
+                                            'name'       => 'foo']]]);
    // => SELECT * FROM `glpi_computers` WHERE (`is_deleted` = 0 OR `name` = 'foo')"
 
-   $DB->request('glpi_computers', 'WHERE' => ['NOT' => ['id' => [1,2,7]]]);
+   $DB->request(['FROM' => 'glpi_computers', 'WHERE' => ['NOT' => ['id' => [1,2,7]]]]);
    // => SELECT * FROM `glpi_computers` WHERE NOT (`id` IN (1, 2, 7))
 
 
@@ -357,9 +357,9 @@ Using a more complex expression with ``AND`` and ``OR``:
 .. code-block:: php
 
     <?php
-    $DB->request('glpi_computers', ['is_deleted' => 0,
+    $DB->request(['FROM' => 'glpi_computers', 'WHERE' => ['is_deleted' => 0,
         ['OR' => ['name' => 'foo', 'otherserial' => 'otherunique']],
-        ['OR' => ['locations_id' => 1, 'serial' => 'unique']]
+        ['OR' => ['locations_id' => 1, 'serial' => 'unique']]]
     ]);
     // => SELECT * FROM `glpi_computers` WHERE `is_deleted` = '0' AND ((`name` = 'foo' OR `otherserial` = 'otherunique')) AND ((`locations_id` = '1' OR `serial` = 'unique'))
 
@@ -371,10 +371,10 @@ Default operator is ``=``, but other operators can be used, by giving an array c
 .. code-block:: php
 
    <?php
-   $DB->request('glpi_computers', ['date_mod' => ['>' , '2016-10-01']]);
+   $DB->request(['FROM' => 'glpi_computers', 'WHERE' => ['date_mod' => ['>' , '2016-10-01']]]);
    // => SELECT * FROM `glpi_computers` WHERE `date_mod` > '2016-10-01'
 
-   $DB->request('glpi_computers', ['name' => ['LIKE' , 'pc00%']]);
+   $DB->request(['FROM' => 'glpi_computers', 'WHERE' => ['name' => ['LIKE' , 'pc00%']]]);
    // => SELECT * FROM `glpi_computers` WHERE `name` LIKE 'pc00%'
 
 Known operators are ``=``, ``!=``, ``<``, ``<=``, ``>``, ``>=``, ``LIKE``, ``REGEXP``, ``NOT LIKE``, ``NOT REGEX``, ``&`` (BITWISE AND), and ``|`` (BITWISE OR).
@@ -387,7 +387,7 @@ You can use SQL aliases (SQL ``AS`` keyword). To achieve that, just write the al
 .. code-block:: php
 
    <?php
-   $DB->request('glpi_computers AS c');
+   $DB->request(['FROM' => 'glpi_computers AS c']);
    // => SELECT * FROM `glpi_computers` AS `c`
 
    $DB->request(['SELECT' => 'field AS f', 'FROM' => 'glpi_computers AS c']);
@@ -474,7 +474,7 @@ For example, to use the SQL `NOW()` function:
    $DB->request([
       'FROM'   => 'my_table',
       'WHERE'  => [
-         'date_end'  => ['>', Glpi\DBAL\QueryFunction::now()]
+         'date_end'  => ['>', \Glpi\DBAL\QueryFunction::now()]
       ]
    ]);
    // SELECT * FROM `my_table` WHERE `date_end` > NOW()

--- a/source/devapi/database/dbiterator.rst
+++ b/source/devapi/database/dbiterator.rst
@@ -537,3 +537,5 @@ You can use a QueryExpression object in the FROM statement:
       'FROM'      => new QueryExpression('(SELECT * FROM glpi_computers) as computers'),
    ]);
    // => SELECT * FROM (SELECT * FROM glpi_computers) as computers
+
+When you need to manually quote identifies or values, it is recommended that you use ``$DB::quoteName`` and ``$DB::quoteValue`` respectively rather than directly adding the quotes to ensure future compatibility.

--- a/source/devapi/database/dbiterator.rst
+++ b/source/devapi/database/dbiterator.rst
@@ -43,8 +43,8 @@ Giving full SQL statement
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If your query cannot be made using the array format, you can give the full SQL statement as a string.
-Otherwise, you should use the array format.
 However, in almost every case, that is not required.
+Otherwise, you should use the array format.
 
 .. note::
 


### PR DESCRIPTION
- Update docs regarding SQL functions to reflect the new way to handle them in GLPI 10.1.
- Remove references to specifying the table in the first parameter of the `request` method as it has been deprecated for a while.
- Added a few clarifications regarding array values in criteria, null values, etc.