### PR TITLE
Added information

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/source/plugins/guidelines.rst
+++ b/source/plugins/guidelines.rst
@@ -60,8 +60,7 @@ In GLPI 10 and newer installations you are adviced to use namespaces and compose
 
 The the convention to be used is (Case sensitive): `namespace GlpiPlugin\Myplugin;`. The namespace should be added to every classfile in the `/src` directory and should be PHP convention be placed in the top of your classfile. Classfiles using the `GlpiPlugin\Myplugin\` namespaces will be loaded from:  `GLPI_ROOT\Plugins\myplugin\src\ClassName.php`. To include folders inside the `src` directory simply add them using the ucfirst convention. i.e. `namespace GlpiPlugin\Myplugin\SubFolder\` will load `GLPI_ROOT\Plugins\myplugin\src\SubFolder\ClassName.php`.
 
-Namespace & use mapping table:
-.. list-table:: Title
+.. list-table:: Namespace & use mapping table
    :widths: 50 50
    :header-rows: 1
 * - Namespace element

--- a/source/plugins/guidelines.rst
+++ b/source/plugins/guidelines.rst
@@ -6,6 +6,9 @@ Guidelines
 Directories structure
 ^^^^^^^^^^^^^^^^^^^^^
 
+PRE GLPI10
+++++++++++
+
 Real structure will depend of what your plugin propose. See :doc:`requirements <requirements>` to find out what is needed. You may also want to :ref:`take a look at GLPI File Hierarchy Standard <fhs>`.
 
 .. warning::
@@ -49,6 +52,20 @@ The plugin directory structure should look like the following:
 * a `LICENSE` file containing the license,
 * `MyPlugin.xml` and `MyPlugin.png` can be used to reference your plugin on the `plugins directory website <http://plugins.glpi-project.org>`_,
 * the required `setup.php` and `hook.php` files.
+
+POST GLPI10
++++++++++++
+
+In GLPI 10 and newer installations you are adviced to use namespaces and composer autoloader. Objectfiles using namespaces are no longer loaded by the old autoload.function.php but by the newer Composer autoloader. In order to use the composer autoloader in your plugin must place your classfiles in the `src/` directory instead of the `inc/`. In this scenario the `/inc` directory should no longer be present in the plugin folder structure.
+
+The the convention to be used is (Case sensitive): `namespace GlpiPlugin\Myplugin;`. The namespace should be added to every classfile in the `/src` directory and should be PHP convention be placed in the top of your classfile. Classfiles using the `GlpiPlugin\Myplugin\` namespaces will be loaded from:  `GLPI_ROOT\Plugins\myplugin\src\ClassName.php`. To include folders inside the `src` directory simply add them using the ucfirst convention. i.e. `namespace GlpiPlugin\Myplugin\SubFolder\` will load `GLPI_ROOT\Plugins\myplugin\src\SubFolder\ClassName.php`.
+
+Namespace mapping table:
+|GlpiPlugin\|/plugins/ or /marketplace/|
+|MyPlugin| /myplugin/src/ `strtolower`|
+|ClassName | /ClassName.php `original`|
+|SubFolder | /SubFolder `original`| 
+
 
 Where to write files?
 +++++++++++++++++++++

--- a/source/plugins/guidelines.rst
+++ b/source/plugins/guidelines.rst
@@ -6,7 +6,7 @@ Guidelines
 Directories structure
 ^^^^^^^^^^^^^^^^^^^^^
 
-PRE GLPI10
+PRE GLPI 10
 ++++++++++
 
 Real structure will depend of what your plugin propose. See :doc:`requirements <requirements>` to find out what is needed. You may also want to :ref:`take a look at GLPI File Hierarchy Standard <fhs>`.
@@ -53,54 +53,80 @@ The plugin directory structure should look like the following:
 * `MyPlugin.xml` and `MyPlugin.png` can be used to reference your plugin on the `plugins directory website <http://plugins.glpi-project.org>`_,
 * the required `setup.php` and `hook.php` files.
 
-POST GLPI10
+POST GLPI 10
 +++++++++++
 
-In GLPI 10 and newer installations you are adviced to use namespaces and composer autoloader. Objectfiles using namespaces are no longer loaded by the old autoload.function.php but by the newer Composer autoloader. In order to use the composer autoloader in your plugin must place your classfiles in the `src/` directory instead of the `inc/`. In this scenario the `/inc` directory should no longer be present in the plugin folder structure.
+In GLPI 10 and newer installations you are adviced to use namespaces and composer autoloader. Objectfiles using namespaces are no longer loaded by the old autoload.function.php but by the newer Composer autoloader. In order to use the composer autoloader in your plugin must place your classfiles in the `/src` directory instead of the `/inc`. In this scenario the `/inc` directory should no longer be present in the plugin folder structure.
 
-The the convention to be used is (Case sensitive): `namespace GlpiPlugin\Myplugin;`. The namespace should be added to every classfile in the `/src` directory and should be PHP convention be placed in the top of your classfile. Classfiles using the `GlpiPlugin\Myplugin\` namespaces will be loaded from:  `GLPI_ROOT\Plugins\myplugin\src\ClassName.php`. To include folders inside the `src` directory simply add them using the ucfirst convention. i.e. `namespace GlpiPlugin\Myplugin\SubFolder\` will load `GLPI_ROOT\Plugins\myplugin\src\SubFolder\ClassName.php`.
+The the convention to be used is (Case sensitive): `namespace GlpiPlugin\Myplugin;`. The namespace should be added to every classfile in the `/src` directory and should be PHP convention be placed in the top of your classfile. Classfiles using the `GlpiPlugin\Myplugin\` namespaces will be loaded from:  `GLPI_ROOT\Plugins\myplugin\src\ClassName.php`. To include folders inside the `/src` directory simply add them to your namespace and use keywords i.e. `namespace GlpiPlugin\Myplugin\SubFolder\` will load `GLPI_ROOT\Plugins\myplugin\src\SubFolder\ClassName.php`.
 
-.. list-table:: "mapping"
-   :widths: 50 50
-   :header-rows: 1
-* - Namespace element
-  - Compose path mapping
-* - GlpiPlugin\
-  - Maps to `/plugins` or `/marketplace/`
-* - MyPlugin\
-  - Maps to /myplugin/src in `strtolower`
-* - SubFolder\
-  - Maps to: /SubFolder in provided case
-* - ClassName
-  - Maps to: ClassName.php in provided case
++-------------+------------------------------------------------------------+
+| Directive   | Composer mapping                                           |
++=============+============================================================+
+| \GlpiPlugin | maps to /plugins or /marketplace                           |
++-------------+------------------------------------------------------------+
+| \MyPlugin   | maps to: /myplugin/src converted strtolower                |
++-------------+------------------------------------------------------------+
+| \SubFolder  | maps to /src/SubFolder/ using provided case                |
++-------------+------------------------------------------------------------+
+| \ClassName  | maps to ../ClassName.php using provided case apending .php |
++-------------+------------------------------------------------------------+
 
-Examples:
-`GLPI_ROOT/marketplace/myplugin/src/Test.php`
-code-block:: php
-<?php
-namespace GlpiPlugin\MyPlugin;
-class Test extends CommonDBTM
-{
-\\...
-}
-?>
 
-`GLPI_ROOT/marketplace/myplugin/setup.php`
-code-block:: php
-<?php
-use GlpiPlugin\MyPlugin\Test;
-function usingTest() : void
-{
-   $test = new Test();
-}
-?>
+GLPI_ROOT/marketplace/myplugin/src/Test.php
+
+.. code-block:: php
+
+  <?php
+
+    namespace GlpiPlugin\MyPlugin;
+
+    class Test extends CommonDBTM
+    {
+      \\ Your class code...
+    }
+
+  ?>
+
+GLPI_ROOT/marketplace/myplugin/src/ChildClass/ResultOutcomes.php
+
+.. code-block:: php
+
+  <?php
+
+    namespace GlpiPlugin\MyPlugin\ChildClass;
+
+    class ResultOutcomes extends CommonDBTM
+    {
+      \\ Your class code...
+    }
+
+  ?>
+
+GLPI_ROOT/marketplace/myplugin/setup.php
+
+.. code-block:: php
+
+  <?php
+
+  use GlpiPlugin\MyPlugin\Test;
+  use GlpiPlugin\Myplugin\ChildClass\ResultOutcomes;
+
+  function usingTest() : void
+  {
+    $t = new Test();
+    $r = new ResultOutcomes();
+  }
+
+  ?>
+
 
 Where to write files?
 +++++++++++++++++++++
 
 .. warning::
 
-   Plugins my never ask user to give them write access on their own directory!
+   Plugins may never ask user to give them write access on their own directory!
 
 The GLPI installation already ask for administrator to get write access on its ``files`` directory; just use ``GLPI_PLUGIN_DOC_DIR/{plugin_name}`` (that would resolve to ``glpi_dir/files/_plugins/{plugin_name}`` in default basic installations).
 

--- a/source/plugins/guidelines.rst
+++ b/source/plugins/guidelines.rst
@@ -60,7 +60,7 @@ In GLPI 10 and newer installations you are adviced to use namespaces and compose
 
 The the convention to be used is (Case sensitive): `namespace GlpiPlugin\Myplugin;`. The namespace should be added to every classfile in the `/src` directory and should be PHP convention be placed in the top of your classfile. Classfiles using the `GlpiPlugin\Myplugin\` namespaces will be loaded from:  `GLPI_ROOT\Plugins\myplugin\src\ClassName.php`. To include folders inside the `src` directory simply add them using the ucfirst convention. i.e. `namespace GlpiPlugin\Myplugin\SubFolder\` will load `GLPI_ROOT\Plugins\myplugin\src\SubFolder\ClassName.php`.
 
-.. list-table:: "Namespace & use mapping table"
+.. list-table:: "mapping"
    :widths: 50 50
    :header-rows: 1
 * - Namespace element

--- a/source/plugins/guidelines.rst
+++ b/source/plugins/guidelines.rst
@@ -60,7 +60,7 @@ In GLPI 10 and newer installations you are adviced to use namespaces and compose
 
 The the convention to be used is (Case sensitive): `namespace GlpiPlugin\Myplugin;`. The namespace should be added to every classfile in the `/src` directory and should be PHP convention be placed in the top of your classfile. Classfiles using the `GlpiPlugin\Myplugin\` namespaces will be loaded from:  `GLPI_ROOT\Plugins\myplugin\src\ClassName.php`. To include folders inside the `src` directory simply add them using the ucfirst convention. i.e. `namespace GlpiPlugin\Myplugin\SubFolder\` will load `GLPI_ROOT\Plugins\myplugin\src\SubFolder\ClassName.php`.
 
-.. list-table:: Namespace & use mapping table
+.. list-table:: "Namespace & use mapping table"
    :widths: 50 50
    :header-rows: 1
 * - Namespace element

--- a/source/plugins/guidelines.rst
+++ b/source/plugins/guidelines.rst
@@ -60,12 +60,41 @@ In GLPI 10 and newer installations you are adviced to use namespaces and compose
 
 The the convention to be used is (Case sensitive): `namespace GlpiPlugin\Myplugin;`. The namespace should be added to every classfile in the `/src` directory and should be PHP convention be placed in the top of your classfile. Classfiles using the `GlpiPlugin\Myplugin\` namespaces will be loaded from:  `GLPI_ROOT\Plugins\myplugin\src\ClassName.php`. To include folders inside the `src` directory simply add them using the ucfirst convention. i.e. `namespace GlpiPlugin\Myplugin\SubFolder\` will load `GLPI_ROOT\Plugins\myplugin\src\SubFolder\ClassName.php`.
 
-Namespace mapping table:
-|GlpiPlugin\|/plugins/ or /marketplace/|
-|MyPlugin| /myplugin/src/ `strtolower`|
-|ClassName | /ClassName.php `original`|
-|SubFolder | /SubFolder `original`| 
+Namespace & use mapping table:
+.. list-table:: Title
+   :widths: 50 50
+   :header-rows: 1
+* - Namespace element
+  - Compose path mapping
+* - GlpiPlugin\
+  - Maps to `/plugins` or `/marketplace/`
+* - MyPlugin\
+  - Maps to /myplugin/src in `strtolower`
+* - SubFolder\
+  - Maps to: /SubFolder in provided case
+* - ClassName
+  - Maps to: ClassName.php in provided case
 
+Examples:
+`GLPI_ROOT/marketplace/myplugin/src/Test.php`
+code-block:: php
+<?php
+namespace GlpiPlugin\MyPlugin;
+class Test extends CommonDBTM
+{
+\\...
+}
+?>
+
+`GLPI_ROOT/marketplace/myplugin/setup.php`
+code-block:: php
+<?php
+use GlpiPlugin\MyPlugin\Test;
+function usingTest() : void
+{
+   $test = new Test();
+}
+?>
 
 Where to write files?
 +++++++++++++++++++++


### PR DESCRIPTION
1. About how to use namespaces and composer autoloader. 

2. Maybe add information about future support. Will this be the standard.

3. I also think it is wise to add the instruction somewhere to "NOT" use existing GLPI classnames inside the plugin namespace or renaming them using:  `use GlpiPlugins\Namespace\ExistingObjectName as SomethingElse;`. I noticed doing so with extends on other existing GLPI objects like CommonDropdown will make the resulting functionality pretty flaky. It should be easy to come up with unique class names.