### PR TITLE
Basic documentation for new Vue support

### DIFF
--- a/source/devapi/index.rst
+++ b/source/devapi/index.rst
@@ -15,4 +15,5 @@ Apart from the current documentation, you can also generate the full PHP documen
    acl
    crontasks
    tools
+   javascript
    extra

--- a/source/devapi/javascript.rst
+++ b/source/devapi/javascript.rst
@@ -1,0 +1,53 @@
+Javascript
+==========
+
+Vue.js
+------
+
+Starting in GLPI 10.1, we have added support for Vue.
+.. note::
+
+    Only SFCs (Single-file Components) using the Components API is supported. Do not use the Options API.
+
+To ease integration, there is no Vue app mounted on the page body itself. Instead, each specific feature that uses Vue such as the debug toolbar mounts its own Vue app on a container element.
+Components must all be located in the ``js/src/vue`` folder for them to be built.
+Components should be grouped into subfolders as a sort of namespace separation.
+There are some helpers stored in the ``window.Vue`` global to help manage components and mount apps.
+
+### Building
+
+Two npm commands exist which can be used to build or watch (auto-build when the sources change) the Vue components.
+
+.. code-block:: bash
+
+   npm run build:vue
+
+.. code-block:: bash
+
+   npm run watch:vue
+
+
+The ``npm run build`` command will also build the Vue components in addition to the regular JS bundles.
+
+To improve performance, the components are not built into a single file. Instead, webpack chunking is utilized.
+This results a single smaller entrypoint ``app.js`` being generated and a separate file for each component.
+The components that are automatically built utilize ``defineAsyncComponent`` to enable the loading of those components on demand.
+
+Further optimizations can be done by directly including a Vue component inside a main component to ensure it is built into the main component's chunk to reduce the number of requests.
+This could be useful if the component wouldn't be reused elsewhere. Just note that the child component would also have its own chunk generated since there is no way to exclude it.
+
+### Mounting
+
+The Vue `createApp` function can be located at `window.Vue.createApp`.
+Each automatically built component is automatically tracked in `window.Vue.components`.
+
+To create an app and mount a component, you can use the following code:
+
+.. code-block:: javascript
+
+   const app = window.Vue.createApp(window.Vue.components['Debug/Toolbar'].component);
+   app.mount('#my-app-wrapper');
+
+Replace ``Debug/Toolbar`` with the relative path to your component without the ``.vue`` extension and ``#my-app-wrapper`` with an ID selector for the wrapper element which would need to already existing in the DOM.
+
+For more information about Vue, please refer to the `official documentation <https://vuejs.org/guide/introduction.html>`_.

--- a/source/plugins/index.rst
+++ b/source/plugins/index.rst
@@ -26,3 +26,4 @@ If you want to see more advanced examples of what it is possible to do with plug
    tips
    notifications
    test
+   javascript

--- a/source/plugins/javascript.rst
+++ b/source/plugins/javascript.rst
@@ -21,7 +21,7 @@ Sample webpack config (derived from the config used in GLPI itself for Vue):
         },
         externals: {
             // prevent duplicate import of Vue library (already done in ../../public/build/vue/app.js)
-            vue: 'import vue',
+            vue: 'window _vue',
         },
         output: {
             filename: 'app.js',
@@ -81,9 +81,10 @@ Sample webpack config (derived from the config used in GLPI itself for Vue):
     module.exports = config
 
 Note the use of the ``externals`` option. This will prevent webpack from including Vue itself when building your components since it is already imported by the bundle in GLPI itself.
+The core GLPI bundle sets ``window._vue`` to the vue module and the plugin's externals option will map any imports from 'vue' to that.
 This will drastically reduce the size of your imports.
 
-For your entrypoint, it is mostly the same as the core GLPi one except you should use the ``defineAsyncComponent`` method in ``window.Vue`` instead of importing it from Vue itself.
+For your entrypoint, it is mostly the same as the core GLPI one except you should use the ``defineAsyncComponent`` method in ``window.Vue`` instead of importing it from Vue itself.
 
 Example entrypoint:
 

--- a/source/plugins/javascript.rst
+++ b/source/plugins/javascript.rst
@@ -1,0 +1,110 @@
+Javascript
+==========
+
+Vue.js
+------
+
+Please refer to :doc:`the core Vue developer documentation first <../devapi/javascript>`.
+
+Plugins that wish to use custom Vue components must implement their own webpack config to build the components and add them to the `window.Vue.components` object.
+
+Sample webpack config (derived from the config used in GLPI itself for Vue):
+.. code-block:: javascript
+
+    const webpack = require('webpack');
+    const path = require('path');
+    const VueLoaderPlugin = require('vue-loader').VueLoaderPlugin;
+
+    const config = {
+        entry: {
+            'vue': './js/src/vue/app.js',
+        },
+        externals: {
+            // prevent duplicate import of Vue library (already done in ../../public/build/vue/app.js)
+            vue: 'import vue',
+        },
+        output: {
+            filename: 'app.js',
+            chunkFilename: "[name].js",
+            chunkFormat: 'module',
+            path: path.resolve(__dirname, 'public/build/vue'),
+            publicPath: '/public/build/vue/',
+            asyncChunks: true,
+            clean: true,
+        },
+        module: {
+            rules: [
+                {
+                    // Vue SFC
+                    test: /\.vue$/,
+                    loader: 'vue-loader'
+                },
+                {
+                    // Build styles
+                    test: /\.css$/,
+                    use: ['style-loader', 'css-loader'],
+                },
+            ]
+        },
+        plugins: [
+            new VueLoaderPlugin(), // Vue SFC support
+            new webpack.ProvidePlugin(
+                {
+                    process: 'process/browser'
+                }
+            ),
+            new webpack.DefinePlugin({
+                __VUE_OPTIONS_API__: false, // We will only use composition API
+                __VUE_PROD_DEVTOOLS__: false,
+            }),
+        ],
+        resolve: {
+            fallback: {
+                'process/browser': require.resolve('process/browser.js')
+            },
+        },
+        mode: 'none', // Force 'none' mode, as optimizations will be done on release process
+        devtool: 'source-map', // Add sourcemap to files
+        stats: {
+            // Limit verbosity to only usefull information
+            all: false,
+            errors: true,
+            errorDetails: true,
+            warnings: true,
+
+            entrypoints: true,
+            timings: true,
+        },
+        target: "es2020"
+    };
+
+    module.exports = config
+
+Note the use of the ``externals`` option. This will prevent webpack from including Vue itself when building your components since it is already imported by the bundle in GLPI itself.
+This will drastically reduce the size of your imports.
+
+For your entrypoint, it is mostly the same as the core GLPi one except you should use the ``defineAsyncComponent`` method in ``window.Vue`` instead of importing it from Vue itself.
+
+Example entrypoint:
+
+.. code-block:: javascript
+
+    // Require all Vue SFCs in js/src directory
+    const component_context = import.meta.webpackContext('.', {
+        regExp: /\.vue$/i,
+        recursive: true,
+        mode: 'lazy',
+        chunkName: '/vue-sfc/[request]'
+    });
+    const components = {};
+    component_context.keys().forEach((f) => {
+        const component_name = f.replace(/^\.\/(.+)\.vue$/, '$1');
+        components[component_name] = {
+            component: window.Vue.defineAsyncComponent(() => component_context(f)),
+        };
+    });
+    // Save components in global scope
+    window.Vue.components = Object.assign(window.Vue.components || {}, components);
+
+To keep your components from colliding with core components or other plugins, it you should organize them inside the `js/src/Plugin/Yourplugin` folder.
+This will ensure plugin components are registered as ``Plugin/Yourplugin/YourComponent``. You can organize components further with additional subfolders.


### PR DESCRIPTION
Basic explanation about how Vue components are built and used, and the variables/methods exposed in `window.Vue`.

For plugins, there is a basic guideline for setting up webpack to build their own components without including another useless copy of Vue in the build and explain how their components should be organized.