### PR TITLE
Reword the `Resource access restrictions` chapter

### DIFF
--- a/source/upgradeguides/glpi-11.0.rst
+++ b/source/upgradeguides/glpi-11.0.rst
@@ -95,12 +95,14 @@ Resource access restrictions
 
 In GLPI 11.0, we restrict the resources that can be accessed through a web request.
 
-We still support access to the PHP scripts located in the ``/ajax``, ``/front`` and ``/report`` directories.
-Their URL remains unchanged, for instance, the URL of the ``/front/index.php`` script of your plugin remains ``/plugins/myplugin/front/index.php``.
+To ease the migration to GLPI 11.0, we still support public access to the PHP scripts located in the ``/ajax``, ``/front`` and ``/report`` directories,
+and their URL remains unchanged.
 
-The static assets must be moved in the ``/public`` directory to be accessible.
-Their URL must not contain the ``/public`` path.
-For instance, the URL of the ``/public/css/styles.css`` stylesheet of your plugin will be ``/plugins/myplugin/css/styles.css``.
+All static assets or other PHP scripts that must be accessible through a web request must be moved in the ``/public`` directory.
+The ``/public`` part of the path must not be present in their URL, for instance:
+
+* the URL of the ``/public/css/styles.css`` stylesheet of your plugin will be ``/plugins/myplugin/css/styles.css``;
+* the URL of the ``/public/mypluginapi.php`` script of your plugin will be ``/plugins/myplugin/mypluginapi.php``.
 
 Legacy scripts access policy
 ++++++++++++++++++++++++++++


### PR DESCRIPTION
I reworded the `Resource access restrictions` chapter to try to clarify how PHP scripts that are supposed to be accessible through a web request, but are not inside the `/ajax`, `/front` or `/report` directories, must be moved to remains accessible in GLPI 11.0.