### PR TITLE
Make the Makefile usable without a host Sphinx install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,14 @@ PAPER         =
 BUILDDIR      = build
 SPHINXAUTOBUILD = sphinx-autobuild
 
-# User-friendly check for sphinx-build
+# User-friendly check for sphinx-build, skipped for Docker/meta goals which
+# don't need Sphinx on the host (it runs inside the "docs" container instead).
+DOCKER_GOALS = help build up watch down
+NON_DOCKER_GOALS := $(filter-out $(DOCKER_GOALS),$(or $(MAKECMDGOALS),help))
+ifneq ($(NON_DOCKER_GOALS),)
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
 $(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+endif
 endif
 
 # Internal variables.
@@ -52,7 +57,7 @@ help: ## Show this help message
 	@echo ""
 
 ## —— Docker ———————————————————————————————————————————————————————————————————
-.PHONY: build start stop kill bash
+.PHONY: build start stop
 
 build: ## Build the Docker images
 	$(COMPOSE) pull
@@ -61,7 +66,6 @@ build: ## Build the Docker images
 
 up: ## Start all containers
 	$(COMPOSE) up -d
-	@echo "\033[32m▶ Documentation available at: http://localhost:8007 \033[0m"
 .PHONY: start
 
 watch: ## Start containers and run livehtml with live console output
@@ -72,15 +76,6 @@ watch: ## Start containers and run livehtml with live console output
 down: ## Stop the containers
 	$(COMPOSE) down --remove-orphans
 .PHONY: stop
-
-kill: ## Stop the containers and remove the volumes
-	$(COMPOSE) kill
-	$(COMPOSE) down --volumes --remove-orphans
-.PHONY: kill
-
-bash: ## Start a shell inside the php container
-	$(DOCS) bash
-.PHONY: bash
 
 ## —— Sphinx ———————————————————————————————————————————————————————————————————
 .PHONY: clean html livehtml dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf latexpdfja text man texinfo info gettext changes linkcheck doctest xml pseudoxml

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ or
 ```shell
 make up
 ```
-Doc is available at http://localhost:8007/
+This only starts the container; it does not serve the documentation yet.
 
-To start with live rebuild output visible in the console (useful to see errors):
+To build and serve the documentation, with live rebuild on changes and console output (useful to see errors):
 ```shell
 make watch
 ```
+Doc is then available at http://localhost:8007/
 
 ### Using your machine 
 


### PR DESCRIPTION
makefile can be used with docker, without `sphinx` local install.
Local usage still work (I suppose, need to be reviewed by someone using it).

The `kill` and `bash` targets were removed (useless, for me at least).

**Security considerations:** N/A (build tooling and docs only).

**Testing:** with Sphinx *not* installed on the host, `make help`, `make up`, `make watch`, `make down` should work; `make html` should still fail with the explicit Sphinx error message.
